### PR TITLE
Remove superfluous packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,12 @@
 # This is a comprehensive requirements.txt file to ensure that one installation covers everything.
 
 # Core dependencies
-azure.storage.blob
-azure.identity
 ipykernel
 matplotlib
 pandas
 pyjwt
 python-dotenv
 requests
-setuptools
 
 # Dev tools for linting, formatting, testing, etc.
 pylint>=3.0.0


### PR DESCRIPTION
Removing several packages that are not / no longer needed. This elegantly removes the dependency of `nbconvert` as well. That package has had a security issue with no path to a newer version.