### PR TITLE
Change from pip to uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-- package-ecosystem: pip
+- package-ecosystem: uv
   directory: "/"
   schedule:
     interval: daily


### PR DESCRIPTION
Originally, APIM Samples uses `pip`. Eventually, it changed to `uv`, but I missed updated dependabot's configuration. Consequently, we have seen Dependabot alerts that are not applicable and reference a non-existing `requirements.txt`. 